### PR TITLE
perf/optimize stats

### DIFF
--- a/src/evaluator.cpp
+++ b/src/evaluator.cpp
@@ -1,9 +1,11 @@
 #include "evaluator.h"
 #include "fastqreader.h"
 #include <map>
+#include <unordered_map>
 #include <memory.h>
 #include "nucleotidetree.h"
 #include "knownadapters.h"
+#include "util.h"
 
 Evaluator::Evaluator(Options* opt){
     mOptions = opt;
@@ -62,10 +64,10 @@ int Evaluator::computeSeqLen(string filename) {
     return seqlen;
 }
 
-void Evaluator::computeOverRepSeq(string filename, map<string, long>& hotseqs, int seqlen) {
+void Evaluator::computeOverRepSeq(string filename, std::unordered_map<string, long>& hotseqs, int seqlen) {
     FastqReader reader(filename);
 
-    map<string, long> seqCounts;
+    std::unordered_map<string, long> seqCounts;
 
     const long BASE_LIMIT = 151 * 10000;
     long records = 0;
@@ -99,7 +101,7 @@ void Evaluator::computeOverRepSeq(string filename, map<string, long>& hotseqs, i
         delete r;
     }
     
-    map<string, long>::iterator iter;
+    std::unordered_map<string, long>::iterator iter;
     for(iter = seqCounts.begin(); iter!=seqCounts.end(); iter++) {
         string seq = iter->first;
         long count = iter->second;
@@ -128,7 +130,7 @@ void Evaluator::computeOverRepSeq(string filename, map<string, long>& hotseqs, i
     }
 
     // remove substrings
-    map<string, long>::iterator iter2;
+    std::unordered_map<string, long>::iterator iter2;
     iter = hotseqs.begin(); 
     while(iter!=hotseqs.end()) {
         string seq = iter->first;

--- a/src/evaluator.h
+++ b/src/evaluator.h
@@ -1,12 +1,10 @@
 #ifndef EVALUATOR_H
 #define EVALUATOR_H
 
-#include <stdio.h>
-#include <stdlib.h>
 #include <string>
 #include "options.h"
-#include "util.h"
-#include "read.h"
+#include "read.h" 
+#include <unordered_map>
 
 using namespace std;
 
@@ -20,7 +18,7 @@ public:
     bool isTwoColorSystem();
     void evaluateSeqLen();
     void evaluateOverRepSeqs();
-    void computeOverRepSeq(string filename, map<string, long>& hotseqs, int seqLen);
+    void computeOverRepSeq(string filename, std::unordered_map<string, long>& hotseqs, int seqLen);
     int computeSeqLen(string filename);
 
     static bool test();

--- a/src/htmlreporter.cpp
+++ b/src/htmlreporter.cpp
@@ -1,4 +1,5 @@
 #include "htmlreporter.h"
+#include <array>
 #include <chrono>
 #include <memory.h>
 #include "knownadapters.h"
@@ -342,7 +343,7 @@ void HtmlReporter::reportDuplication(ofstream& ofs) {
 }
 
 void HtmlReporter::reportQualHistogram(ofstream& ofs, string caption, Stats* stats1, Stats* stats2) {
-    long* hist1 = stats1->getQualHist();
+    std::array<long, 128> hist1 = stats1->getQualHist();
 
     string divName = replace(caption, " ", "_");
     divName = replace(divName, ":", "_");
@@ -379,7 +380,7 @@ void HtmlReporter::reportQualHistogram(ofstream& ofs, string caption, Stats* sta
     ofs << "};" << endl;
 
     if(stats2 != NULL) {
-        long* hist2 = stats2->getQualHist();
+        std::array<long, 128> hist2 = stats2->getQualHist();
         ofs << " var hist2 = {" << endl;
         ofs << " x: [";
         first = true;

--- a/src/options.h
+++ b/src/options.h
@@ -4,8 +4,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string>
+#include <unordered_map>
 #include <vector>
-#include <map>
 
 using namespace std;
 
@@ -359,8 +359,8 @@ public:
     PolyXTrimmerOptions polyXTrim;
     // for overrepresentation analysis
     OverrepresentedSequenceAnasysOptions overRepAnalysis;
-    map<string, long> overRepSeqs1;
-    map<string, long> overRepSeqs2;
+    std::unordered_map<string, long> overRepSeqs1;
+    std::unordered_map<string, long> overRepSeqs2;
     int seqLen1;
     int seqLen2;
     // low complexity filtering

--- a/src/stats.cpp
+++ b/src/stats.cpp
@@ -65,11 +65,9 @@ Stats::Stats(Options* opt, bool isRead2, int guessedCycles, int bufferMargin){
     // extend the buffer to make sure it's long enough
     mBufLen = guessedCycles + bufferMargin;
 
-    for (std::size_t i = 0; i < Stats::BaseCount; i++) {
-        mQ20Bases[i] = 0;
-        mQ30Bases[i] = 0;
-        mBaseContents[i] = 0;
-    }
+    mQ20Bases.fill(0);
+    mQ30Bases.fill(0);
+    mBaseContents.fill(0);
 
     mCycleQ30Bases.resize(Stats::BaseCount, mBufLen);
     mCycleQ20Bases.resize(Stats::BaseCount, mBufLen);

--- a/src/stats.cpp
+++ b/src/stats.cpp
@@ -71,11 +71,10 @@ Stats::Stats(Options* opt, bool isRead2, int guessedCycles, int bufferMargin){
         mBaseContents[i] = 0;
     }
 
-    auto totalSize = Stats::BaseCount * static_cast<std::size_t>(mBufLen);
-    mCycleQ30Bases.assign(totalSize, 0);
-    mCycleQ20Bases.assign(totalSize, 0);
-    mCycleBaseContents.assign(totalSize, 0);
-    mCycleBaseQual.assign(totalSize, 0);
+    mCycleQ30Bases.resize(Stats::BaseCount, mBufLen);
+    mCycleQ20Bases.resize(Stats::BaseCount, mBufLen);
+    mCycleBaseContents.resize(Stats::BaseCount, mBufLen);
+    mCycleBaseQual.resize(Stats::BaseCount, mBufLen);
 
     mCycleTotalBase.assign(mBufLen, 0);
     mCycleTotalQual.assign(mBufLen, 0);
@@ -92,23 +91,10 @@ void Stats::extendBuffer(int newBufLen) {
         return;
     }
 
-    const auto oldLen = static_cast<std::size_t>(mBufLen);
-    const auto newSize = Stats::BaseCount * static_cast<std::size_t>(newBufLen);
-
-    auto resizeFlat = [&](BaseCycleArray& arr) {
-        BaseCycleArray newArr(newSize, 0);
-        for (std::size_t baseIdx = 0; baseIdx < Stats::BaseCount; ++baseIdx) {
-            for (std::size_t i = 0; i < oldLen; ++i) {
-                newArr[(baseIdx * newBufLen) + i] = arr[(baseIdx * mBufLen) + i];
-            }
-        }
-        arr.swap(newArr);
-    };
-
-    resizeFlat(mCycleQ30Bases);
-    resizeFlat(mCycleQ20Bases);
-    resizeFlat(mCycleBaseContents);
-    resizeFlat(mCycleBaseQual);
+    mCycleQ30Bases.resize(Stats::BaseCount, mBufLen);
+    mCycleQ20Bases.resize(Stats::BaseCount, mBufLen);
+    mCycleBaseContents.resize(Stats::BaseCount, mBufLen);
+    mCycleBaseQual.resize(Stats::BaseCount, mBufLen);
 
     mCycleTotalBase.resize(newBufLen, 0);
     mCycleTotalQual.resize(newBufLen, 0);
@@ -136,10 +122,9 @@ void Stats::summarize(bool forced) {
     // Q20, Q30, base content
     for (std::size_t i = 0; i < Stats::BaseCount; i++) {
         for(int c=0; c<mCycles; c++) {
-            const auto idx = i * mBufLen + c;
-            mQ20Bases[i] += mCycleQ20Bases[idx];
-            mQ30Bases[i] += mCycleQ30Bases[idx];
-            mBaseContents[i] += mCycleBaseContents[idx];
+            mQ20Bases[i] += mCycleQ20Bases(i, c);
+            mQ30Bases[i] += mCycleQ30Bases(i, c);
+            mBaseContents[i] += mCycleBaseContents(i, c);
         }
         mQ20Total += mQ20Bases[i];
         mQ30Total += mQ30Bases[i];
@@ -168,16 +153,15 @@ void Stats::summarize(bool forced) {
 
         const auto baseOffset = baseIdx * mBufLen;
         for (int c = 0; c < mCycles; c++) {
-            const auto idx = baseOffset + c;
             // TODO: consider reordering the else statement to be first if profiling shows this branch
             // is hot.
-            if (mCycleBaseContents[idx] == 0) {
+            if (mCycleBaseContents(baseIdx, c) == 0) {
                 qualCurve[c] = meanQualCurve[c]; // TODO: can this be moved out the loop?
             }
             else {
-                qualCurve[c] = (double)mCycleBaseQual[idx] / (double)mCycleBaseContents[idx];
+                qualCurve[c] = (double)mCycleBaseQual(baseIdx, c) / (double)mCycleBaseContents(baseIdx, c);
             }
-            contentCurve[c] = (double)mCycleBaseContents[idx] / (double)mCycleTotalBase[c];
+            contentCurve[c] = (double)mCycleBaseContents(baseIdx, c) / (double)mCycleTotalBase[c];
         }
         mQualityCurves[qualityCurveIndex(key)] = std::move(qualCurve);
         mContentCurves[contentCurveIndex(key)] = std::move(contentCurve);
@@ -189,12 +173,8 @@ void Stats::summarize(bool forced) {
     auto gBase = baseIndex('G');
     auto cBase = baseIndex('C');
 
-    const auto gOffset = gBase * mBufLen;
-    const auto cOffset = cBase * mBufLen;
     for(int c=0; c<mCycles; c++) {
-        const auto gIdx = gOffset + c;
-        const auto cIdx = cOffset + c;
-        gcContentCurve[c] = (double)(mCycleBaseContents[gIdx] + mCycleBaseContents[cIdx]) / (double)mCycleTotalBase[c];
+        gcContentCurve[c] = (double)(mCycleBaseContents(gBase, c) + mCycleBaseContents(cBase, c)) / (double)mCycleTotalBase[c];
     }
     mContentCurves[contentCurveIndex(CurveKey::GC)] = std::move(gcContentCurve);
 
@@ -238,12 +218,11 @@ void Stats::statRead(Read* r) {
         const int isQ20 = (qual >= q20) ? 1 : 0;
         const int isQ30 = (qual >= q30) ? 1 : 0;
         
-        const auto idx = (baseIdx * mBufLen) + i;
-        mCycleQ20Bases[idx] += isQ20;
-        mCycleQ30Bases[idx] += isQ30;
+        mCycleQ20Bases(baseIdx, i) += isQ20;
+        mCycleQ30Bases(baseIdx, i) += isQ30;
 
-        mCycleBaseContents[idx]++;
-        mCycleBaseQual[idx] += (qual-33);
+        mCycleBaseContents(baseIdx, i)++;
+        mCycleBaseQual(baseIdx, i) += (qual-33);
 
         mCycleTotalBase[i]++;
         mCycleTotalQual[i] += (qual-33);
@@ -911,25 +890,25 @@ Stats* Stats::merge(vector<Stats*>& list) {
     // init overrepresented seq maps
     std::unordered_map<string, long>::iterator iter;
 
+    const auto sizeA = s->mCycleQ30Bases.cycleLength();
     for(int t=0; t<list.size(); t++) {
         int curCycles =  list[t]->getCycles();
         // merge read number
         s->mReads += list[t]->mReads;
         s->mLengthSum += list[t]->mLengthSum;
 
-        const auto limit = std::min(static_cast<std::size_t>(cycles), static_cast<std::size_t>(curCycles));
+        const auto sizeB = list[t]->mCycleQ30Bases.cycleLength();
+        const auto limit =
+            std::min({static_cast<std::size_t>(cycles), sizeA, sizeB, static_cast<std::size_t>(curCycles)});
+
         // merge per cycle counting for different bases
         for (std::size_t i = 0; i < Stats::BaseCount; i++) {
-
             for (std::size_t j = 0; j < limit; j++) {
                 // TODO: we can move some of these pointers out of the loop as they're invariant
-                const auto dstIndex = (i * s->mBufLen) + j;
-                const auto srcIndex = (i * list[t]->mBufLen) + j;
-
-                s->mCycleQ30Bases[dstIndex] += list[t]->mCycleQ30Bases[srcIndex];
-                s->mCycleQ20Bases[dstIndex] += list[t]->mCycleQ20Bases[srcIndex];
-                s->mCycleBaseContents[dstIndex] += list[t]->mCycleBaseContents[srcIndex];
-                s->mCycleBaseQual[dstIndex] += list[t]->mCycleBaseQual[srcIndex];
+                s->mCycleQ30Bases(i, j) += list[t]->mCycleQ30Bases(i, j);
+                s->mCycleQ20Bases(i, j) += list[t]->mCycleQ20Bases(i, j);
+                s->mCycleBaseContents(i, j) += list[t]->mCycleBaseContents(i, j);
+                s->mCycleBaseQual(i, j) += list[t]->mCycleBaseQual(i, j);
             }
         }
 

--- a/src/stats.cpp
+++ b/src/stats.cpp
@@ -2,6 +2,8 @@
 #include <memory.h>
 #include <algorithm>
 #include <array>
+#include <cstddef>
+#include <cstring>
 #include <sstream>
 #include <string>
 #include <unordered_map>
@@ -10,7 +12,28 @@
 
 #define KMER_LEN 5
 
-// TODO: this is doing way too much, clean it up.
+static const std::array<Stats::CurveKey, Stats::QualityCurveSize> QualityOrder = {Stats::CurveKey::A,
+                                                                                  Stats::CurveKey::T,
+                                                                                  Stats::CurveKey::C,
+                                                                                  Stats::CurveKey::G,
+                                                                                  Stats::CurveKey::Mean};
+
+static const std::array<Stats::CurveKey, Stats::ContentCurveSize> ContentOrder = {Stats::CurveKey::A,
+                                                                                  Stats::CurveKey::T,
+                                                                                  Stats::CurveKey::C,
+                                                                                  Stats::CurveKey::G,
+                                                                                  Stats::CurveKey::GC};
+
+static const std::array<const char*, Stats::QualityCurveSize> QualityNames = {"A", "T", "C", "G", "mean"};
+
+static const std::array<const char*, Stats::ContentCurveSize> ContentNames = {"A", "T", "C", "G", "N", "GC"};
+
+static const std::array<std::size_t, Stats::CurveIndexSize> QualityIndex =
+    {0, 1, 2, 3, Stats::InvalidIndex, 4, Stats::InvalidIndex};
+
+static const std::array<std::size_t, Stats::CurveIndexSize> ContentIndex = {0, 1, 2, 3, 4, Stats::InvalidIndex, 5};
+
+// TODO: this is doing way too much, clean it up,
 // We should use direct initialization syntax
 Stats::Stats(Options* opt, bool isRead2, int guessedCycles, int bufferMargin){
     mOptions = opt;
@@ -281,6 +304,14 @@ auto Stats::base2val(char base) noexcept -> int {
     }();
 
     return base_to_value_lookup[static_cast<unsigned char>(base)];
+}
+
+auto Stats::qualityCurveIndex(CurveKey key) noexcept -> std::size_t {
+    return QualityIndex[static_cast<std::size_t>(key)];
+}
+
+auto Stats::contentCurveIndex(CurveKey key) noexcept -> std::size_t {
+    return ContentIndex[static_cast<std::size_t>(key)];
 }
 
 int Stats::getCycles() {

--- a/src/stats.cpp
+++ b/src/stats.cpp
@@ -77,7 +77,7 @@ Stats::Stats(Options* opt, bool isRead2, int guessedCycles, int bufferMargin){
     mCycleTotalQual.assign(mBufLen, 0);
 
     // allocate k-mer counting buffer
-    mKmer.assign(KmerCount, 0);
+    mKmer.fill(0);
 
     initOverRepSeq();
 }
@@ -666,7 +666,7 @@ string Stats::makeKmerTD(int i, int j) {
     string first = kmer3(i);
     string last = kmer2(j);
     string kmer = first+last;
-    double meanBases = (double)(mBases+1) / mKmer.size();
+    double meanBases = (double)(mBases+1) / static_cast<double>(Stats::KmerCount);
     double prop = val / meanBases;
     double frac = 0.5;
     if(prop > 2.0) 
@@ -924,7 +924,7 @@ Stats* Stats::merge(vector<Stats*>& list) {
         }
 
         // merge kMer
-        for(std::size_t i = 0; i < s->mKmer.size(); i++) {
+        for(std::size_t i = 0; i < Stats::KmerCount; i++) {
             s->mKmer[i] += list[t]->mKmer[i];
         }
 

--- a/src/stats.cpp
+++ b/src/stats.cpp
@@ -215,12 +215,11 @@ void Stats::statRead(Read* r) {
 
         mBaseQualHistogram[qual]++;
 
-        if(qual >= q30) {
-            mCycleQ30Bases[baseIdx][i]++;
-            mCycleQ20Bases[baseIdx][i]++;
-        } else if(qual >= q20) {
-            mCycleQ20Bases[baseIdx][i]++;
-        }
+        const int isQ20 = (qual >= q20) ? 1 : 0;
+        const int isQ30 = (qual >= q30) ? 1 : 0;
+        
+        mCycleQ20Bases[baseIdx][i] += isQ20;
+        mCycleQ30Bases[baseIdx][i] += isQ30;
 
         mCycleBaseContents[baseIdx][i]++;
         mCycleBaseQual[baseIdx][i] += (qual-33);

--- a/src/stats.cpp
+++ b/src/stats.cpp
@@ -11,7 +11,6 @@
 #include <vector>
 #include "util.h"
 
-#define KMER_LEN 5
 
 static const std::array<Stats::CurveKey, Stats::QualityCurveSize> QualityOrder = {Stats::CurveKey::A,
                                                                                   Stats::CurveKey::T,
@@ -77,9 +76,8 @@ Stats::Stats(Options* opt, bool isRead2, int guessedCycles, int bufferMargin){
     mCycleTotalBase.assign(mBufLen, 0);
     mCycleTotalQual.assign(mBufLen, 0);
 
-    // TODO: this looks to be double the needed size which can skew mean calculations
-    mKmerBufLen = 2<<(KMER_LEN * 2);
-    mKmer.assign(mKmerBufLen, 0);
+    // allocate k-mer counting buffer
+    mKmer.assign(KmerCount, 0);
 
     initOverRepSeq();
 }

--- a/src/stats.cpp
+++ b/src/stats.cpp
@@ -242,14 +242,14 @@ void Stats::statRead(Read* r) {
             continue;
 
         // calc 5 KMER
-        // 0x3FC == 0011 1111 1100
+        // use Stats::KmerMask to maintain a 10-bit rolling k-mer
         if(!needFullCompute){
             int val = base2val(base);
             if(val < 0){
                 needFullCompute = true;
                 continue;
             } else {
-                kmer = ((kmer<<2) & 0x3FC ) | val;
+                kmer = ((kmer<<2) | val) & Stats::KmerMask;
                 mKmer[kmer]++;
             }
         } else {
@@ -261,7 +261,7 @@ void Stats::statRead(Read* r) {
                     valid = false;
                     break;
                 }
-                kmer = ((kmer<<2) & 0x3FC ) | val;
+                kmer = ((kmer<<2) | val) & Stats::KmerMask;
             }
             if(!valid) {
                 needFullCompute = true;

--- a/src/stats.cpp
+++ b/src/stats.cpp
@@ -1,5 +1,6 @@
 #include "stats.h"
 #include <memory.h>
+#include <array>
 #include <sstream>
 #include "util.h"
 
@@ -331,19 +332,23 @@ void Stats::statRead(Read* r) {
     mReads++;
 }
 
-int Stats::base2val(char base) {
-    switch(base){
-        case 'A':
-            return 0;
-        case 'T':
-            return 1;
-        case 'C':
-            return 2;
-        case 'G':
-            return 3;
-        default:
-            return -1;
-    }
+auto Stats::base2val(char base) noexcept -> int {
+    // Static lookup table initialized once using a lambda expression.
+    // The `[]() { ... }()` syntax defines an immediately-invoked lambda expression (IEFE).
+    // This allows us to fill and return the lookup table in a single expression,
+    // and ensures the initialization happens only once in a thread safe manner.
+    static const std::array<signed char, 256> base_to_value_lookup = []() {
+        std::array<signed char, 256> lookup_table;
+
+        lookup_table.fill(-1);  // Default all values to -1 (invalid base)
+        lookup_table['A'] = 0;
+        lookup_table['T'] = 1;
+        lookup_table['C'] = 2;
+        lookup_table['G'] = 3;
+        return lookup_table;
+    }();
+
+    return base_to_value_lookup[static_cast<unsigned char>(base)];
 }
 
 int Stats::getCycles() {

--- a/src/stats.cpp
+++ b/src/stats.cpp
@@ -208,6 +208,11 @@ void Stats::statRead(Read* r) {
     const char q20 = '5';
     const char q30 = '?';
 
+    auto& q20Vec = mCycleQ20Bases.values();
+    auto& q30Vec = mCycleQ30Bases.values();
+    auto& contentVec = mCycleBaseContents.values();
+    auto& qualVec = mCycleBaseQual.values();
+
     for(int i=0; i<len; i++) {
         char base = seqstr[i];
         char qual = qualstr[i];
@@ -218,11 +223,13 @@ void Stats::statRead(Read* r) {
         const int isQ20 = (qual >= q20) ? 1 : 0;
         const int isQ30 = (qual >= q30) ? 1 : 0;
         
-        mCycleQ20Bases(baseIdx, i) += isQ20;
-        mCycleQ30Bases(baseIdx, i) += isQ30;
+        const auto offset = (baseIdx * static_cast<std::size_t>(mBufLen)) + i;
 
-        mCycleBaseContents(baseIdx, i)++;
-        mCycleBaseQual(baseIdx, i) += (qual-33);
+        q20Vec[offset] += isQ20;
+        q30Vec[offset] += isQ30;
+
+        contentVec[offset]++;
+        qualVec[offset] += (qual-33);
 
         mCycleTotalBase[i]++;
         mCycleTotalQual[i] += (qual-33);

--- a/src/stats.cpp
+++ b/src/stats.cpp
@@ -5,6 +5,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
+#include <numeric>
 #include <sstream>
 #include <string>
 #include <unordered_map>
@@ -186,6 +187,7 @@ void Stats::summarize(bool forced) {
     auto minmax = std::minmax_element(mKmer.begin(), mKmer.end());
     mKmerMin = *minmax.first;
     mKmerMax = *minmax.second;
+    mKmerTotal = std::accumulate(mKmer.begin(), mKmer.end(), 0L);
 
     summarized = true;
 }
@@ -671,7 +673,7 @@ string Stats::makeKmerTD(int i, int j) {
     long val = mKmer[target];
     // Retrieve k-mer from cache
     const string& kmer = mKmerLabels[target];
-    double meanBases = (double)(mBases+1) / static_cast<double>(Stats::KmerCount);
+    double meanBases = (double)(mKmerTotal+1) / static_cast<double>(Stats::KmerCount);
     double prop = val / meanBases;
     double frac = 0.5;
     if(prop > 2.0) 
@@ -1017,6 +1019,10 @@ auto Stats::test() -> bool {
     }
 
     if (stats.mKmerMax != 2 || stats.mKmerMin != 0) {
+        return false;
+    }
+
+    if (stats.mKmerTotal != 6) {
         return false;
     }
 

--- a/src/stats.cpp
+++ b/src/stats.cpp
@@ -374,7 +374,7 @@ void Stats::print() {
     cerr << "Q40 bases: " << mQ40Total << "(" << (mQ40Total*100.0)/mBases << "%)" << endl;
 }
 
-void Stats::reportJson(ofstream& ofs, string padding) {
+void Stats::reportJson(ofstream& ofs, const string& padding) {
     ofs << "{" << endl;
 
     ofs << padding << "\t" << "\"total_reads\": " << mReads << "," << endl;
@@ -517,7 +517,7 @@ string Stats::list2string(long* list, int size) {
     return ss.str();
 }
 
-void Stats::reportHtml(ofstream& ofs, string filteringType, string readName) {
+void Stats::reportHtml(ofstream& ofs, const string& filteringType, const string& readName) {
     reportHtmlQuality(ofs, filteringType, readName);
     reportHtmlContents(ofs, filteringType, readName);
     reportHtmlKMER(ofs, filteringType, readName);
@@ -542,7 +542,7 @@ bool Stats::overRepPassed(string& seq, long count) {
     }
 }
 
-void Stats::reportHtmlORA(ofstream& ofs, string filteringType, string readName) {
+void Stats::reportHtmlORA(ofstream& ofs, const string& filteringType, const string& readName) {
     // over represented seqs
     double dBases = mBases;
     std::unordered_map<string, long>::iterator iter;
@@ -631,7 +631,7 @@ bool Stats::isLongRead() {
     return mCycles > 300;
 }
 
-void Stats::reportHtmlKMER(ofstream& ofs, string filteringType, string readName) {
+void Stats::reportHtmlKMER(ofstream& ofs, const string& filteringType, const string& readName) {
 
     // KMER
     string subsection = filteringType + ": " + readName + ": KMER counting";
@@ -715,7 +715,7 @@ string Stats::kmer2(int val) {
     return ret;
 }
 
-void Stats::reportHtmlQuality(ofstream& ofs, string filteringType, string readName) {
+void Stats::reportHtmlQuality(ofstream& ofs, const string& filteringType, const string& readName) {
 
     // quality
     string subsection = filteringType + ": " + readName + ": quality";
@@ -792,7 +792,7 @@ void Stats::reportHtmlQuality(ofstream& ofs, string filteringType, string readNa
     delete[] x;
 }
 
-void Stats::reportHtmlContents(ofstream& ofs, string filteringType, string readName) {
+void Stats::reportHtmlContents(ofstream& ofs, const string& filteringType, const string& readName) {
 
     // content
     string subsection = filteringType + ": " + readName + ": base contents";

--- a/src/stats.h
+++ b/src/stats.h
@@ -121,6 +121,9 @@ public:
         }
 
         auto cycleLength() const -> std::size_t { return bufLen; }
+
+        auto values() -> std::vector<long>& { return data; }
+        auto values() const -> const std::vector<long>& { return data; }
     };
 
     // Compound types for per-base cycle data

--- a/src/stats.h
+++ b/src/stats.h
@@ -105,15 +105,13 @@ public:
         }
 
         void resize(std::size_t base, std::size_t newLen) {
-            const auto newSize = base * newLen;
-            std::vector<long> newData(newSize, 0);
-
+            std::vector<long> newData(base * newLen , 0);
             std::size_t minBase = std::min(base, bases);
-            std::size_t minLen = std::min(newLen, bufLen);
+            std::size_t minLen  = std::min(newLen, bufLen);
 
             for (std::size_t baseIdx = 0; baseIdx < minBase; ++baseIdx) {
                 for (std::size_t cycleIdx = 0; cycleIdx < minLen; ++cycleIdx) {
-                    newData[newSize + cycleIdx] = (*this)(baseIdx, cycleIdx);
+                    newData[(baseIdx * newLen) + cycleIdx] = (*this)(baseIdx, cycleIdx);
                 }
             }
 

--- a/src/stats.h
+++ b/src/stats.h
@@ -94,24 +94,28 @@ public:
         std::size_t bases{0};
         std::size_t bufLen{0};
 
+        auto index(std::size_t cycle, std::size_t base) const noexcept -> std::size_t {
+            return (cycle * bases) + base;
+        }
+
       public:
         BaseCycleArray() = default;
-        BaseCycleArray(std::size_t base, std::size_t len) : data(base * len, 0), bases(base), bufLen(len) {}
+        BaseCycleArray(std::size_t base, std::size_t len) : data(len * base, 0), bases(base), bufLen(len) {}
 
-        auto operator()(std::size_t base, std::size_t cycle) -> long& { return data[(base * bufLen) + cycle]; }
+        auto operator()(std::size_t cycle, std::size_t base) -> long& { return data[index(cycle, base)]; }
 
-        auto operator()(std::size_t base, std::size_t cycle) const -> const long& {
-            return data[(base * bufLen) + cycle];
+        auto operator()(std::size_t cycle, std::size_t base) const -> const long& {
+            return data[index(cycle, base)];
         }
 
         void resize(std::size_t base, std::size_t newLen) {
-            std::vector<long> newData(base * newLen , 0);
+            std::vector<long> newData(newLen * base, 0);
             std::size_t minBase = std::min(base, bases);
             std::size_t minLen  = std::min(newLen, bufLen);
 
-            for (std::size_t baseIdx = 0; baseIdx < minBase; ++baseIdx) {
-                for (std::size_t cycleIdx = 0; cycleIdx < minLen; ++cycleIdx) {
-                    newData[(baseIdx * newLen) + cycleIdx] = (*this)(baseIdx, cycleIdx);
+            for (std::size_t cycleIdx = 0; cycleIdx < minLen; ++cycleIdx) {
+                for (std::size_t baseIdx = 0; baseIdx < minBase; ++baseIdx) {
+                    newData[(cycleIdx * base) + baseIdx] = (*this)(cycleIdx, baseIdx);
                 }
             }
 
@@ -121,6 +125,7 @@ public:
         }
 
         auto cycleLength() const -> std::size_t { return bufLen; }
+        auto baseCount() const -> std::size_t { return bases; }
 
         auto values() -> std::vector<long>& { return data; }
         auto values() const -> const std::vector<long>& { return data; }

--- a/src/stats.h
+++ b/src/stats.h
@@ -31,7 +31,8 @@ public:
     static constexpr std::size_t KmerLen   = 5;
     static constexpr std::size_t KmerCount = 1U << (2 * KmerLen);
     static constexpr std::size_t KmerMask  = KmerCount - 1;
-    using KmerArray = std::array<long, KmerCount>;
+    using KmerArray                        = std::array<long, KmerCount>;
+    using KmerLabelArray                   = std::array<std::string, KmerCount>;
 
     // this @guessedCycles parameter should be calculated using the first several records
     Stats(Options* opt, bool isRead2 = false, int guessedCycles = 0, int bufferMargin = 1024);
@@ -174,6 +175,7 @@ private:
     CountVector mCycleTotalQual;
 
     KmerArray mKmer;
+    KmerLabelArray mKmerLabels{};
 
     //TODO: Replace with const?
     std::array<long, 128> mBaseQualHistogram{}; // Initializing at construction like this is preferred

--- a/src/stats.h
+++ b/src/stats.h
@@ -3,6 +3,8 @@
 
 #include <array>
 #include <cstddef>
+#include <cstdint>
+#include <limits>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -12,6 +14,18 @@
 
 class Stats{
 public:
+    enum class CurveKey: std::uint8_t { A, T, C, G, N, Mean, GC };
+
+    static constexpr std::size_t InvalidIndex = std::numeric_limits<std::size_t>::max();
+
+    static constexpr std::size_t QualityCurveSize = 5;
+    static constexpr std::size_t ContentCurveSize = 6;
+    static constexpr std::size_t CurveIndexSize   = 7;
+
+    static auto qualityCurveIndex(CurveKey key) noexcept -> std::size_t;
+    static auto contentCurveIndex(CurveKey key) noexcept -> std::size_t;
+
+
     // this @guessedCycles parameter should be calculated using the first several records
     Stats(Options* opt, bool isRead2 = false, int guessedCycles = 0, int bufferMargin = 1024);
     ~Stats() = default;

--- a/src/stats.h
+++ b/src/stats.h
@@ -1,5 +1,4 @@
-#ifndef STATS_H
-#define STATS_H
+#pragma once
 
 #include <array>
 #include <cstddef>
@@ -59,22 +58,22 @@ public:
     void print();
     void summarize(bool forced = false);
     // a port of JSON report
-    void reportJson(ofstream& ofs, const string& padding);
+    void reportJson(std::ofstream& ofs, const std::string& padding);
     // a port of HTML report
-    void reportHtml(ofstream& ofs, const string& filteringType, const string& readName);
-    void reportHtmlQuality(ofstream& ofs, const string& filteringType, const string& readName);
-    void reportHtmlContents(ofstream& ofs, const string& filteringType, const string& readName);
-    void reportHtmlKMER(ofstream& ofs, const string& filteringType, const string& readName);
-    void reportHtmlORA(ofstream& ofs, const string& filteringType, const string& readName);
+    void reportHtml(std::ofstream& ofs, const std::string& filteringType, const std::string& readName);
+    void reportHtmlQuality(std::ofstream& ofs, const std::string& filteringType, const std::string& readName);
+    void reportHtmlContents(std::ofstream& ofs, const std::string& filteringType, const std::string& readName);
+    void reportHtmlKMER(std::ofstream& ofs, const std::string& filteringType, const std::string& readName);
+    void reportHtmlORA(std::ofstream& ofs, const std::string& filteringType, const std::string& readName);
     bool isLongRead();
     void initOverRepSeq();
     int getMeanLength();
     static auto test() -> bool;
 
 public:
-    static string list2string(double* list, int size);
-    static string list2string(double* list, int size, long* coords);
-    static string list2string(long* list, int size);
+    static std::string list2string(double* list, int size);
+    static std::string list2string(double* list, int size, long* coords);
+    static std::string list2string(long* list, int size);
 
     // Static lookup array for base values
     static constexpr std::array<signed char, 256> BaseValueLookup = {
@@ -153,11 +152,11 @@ public:
 
 private:
     void extendBuffer(int newBufLen);
-    string makeKmerTD(int i, int j);
-    string kmer3(int val);
-    string kmer2(int val);
+    std::string makeKmerTD(int i, int j);
+    std::string kmer3(int val);
+    std::string kmer2(int val);
     void deleteOverRepSeqDist();
-    bool overRepPassed(string& seq, long count);
+    bool overRepPassed(std::string& seq, long count);
 
 private:
     Options* mOptions;
@@ -177,13 +176,12 @@ private:
     KmerArray mKmer;
     KmerLabelArray mKmerLabels{};
 
-    //TODO: Replace with const?
     std::array<long, 128> mBaseQualHistogram{}; // Initializing at construction like this is preferred
 
     std::array<std::vector<double>, QualityCurveSize> mQualityCurves;
     std::array<std::vector<double>, ContentCurveSize> mContentCurves;
-    std::unordered_map<string, long> mOverRepSeq;
-    std::unordered_map<string, std::vector<long>> mOverRepSeqDist;
+    std::unordered_map<std::string, long> mOverRepSeq;
+    std::unordered_map<std::string, std::vector<long>> mOverRepSeqDist;
 
 
     int mCycles;
@@ -202,4 +200,3 @@ private:
     long mKmerTotal;
 };
 
-#endif

--- a/src/stats.h
+++ b/src/stats.h
@@ -105,8 +105,8 @@ private:
     // Replace with const?
     std::array<long, 128> mBaseQualHistogram{}; // Initializing at construction like this is preferred
 
-    std::unordered_map<string, std::vector<double>> mQualityCurves;
-    std::unordered_map<string, std::vector<double>> mContentCurves;
+    std::array<std::vector<double>, QualityCurveSize> mQualityCurves;
+    std::array<std::vector<double>, ContentCurveSize> mContentCurves;
     std::unordered_map<string, long> mOverRepSeq;
     std::unordered_map<string, std::vector<long>> mOverRepSeqDist;
 

--- a/src/stats.h
+++ b/src/stats.h
@@ -99,7 +99,7 @@ public:
     };
     static auto baseIndex(char base) noexcept -> std::size_t;
     using BaseArray = std::array<long, BaseCount>;
-    using BaseCycleArray = std::array<CountVector, BaseCount>;
+    using BaseCycleArray = std::vector<long>;
 
 private:
     void extendBuffer(int newBufLen);
@@ -125,7 +125,7 @@ private:
     CountVector mCycleTotalQual;
     CountVector mKmer;
 
-    // Replace with const?
+    //TODO: Replace with const?
     std::array<long, 128> mBaseQualHistogram{}; // Initializing at construction like this is preferred
 
     std::array<std::vector<double>, QualityCurveSize> mQualityCurves;

--- a/src/stats.h
+++ b/src/stats.h
@@ -16,6 +16,9 @@ class Stats{
 public:
     enum class CurveKey: std::uint8_t { A, T, C, G, N, Mean, GC };
 
+    enum class BaseIndex : std::uint8_t { A = 0, T, C, G, N, Count };
+    static constexpr std::size_t BaseCount = static_cast<std::size_t>(BaseIndex::Count);
+
     static constexpr std::size_t InvalidIndex = std::numeric_limits<std::size_t>::max();
 
     static constexpr std::size_t QualityCurveSize = 5;
@@ -24,7 +27,6 @@ public:
 
     static auto qualityCurveIndex(CurveKey key) noexcept -> std::size_t;
     static auto contentCurveIndex(CurveKey key) noexcept -> std::size_t;
-
 
     // this @guessedCycles parameter should be calculated using the first several records
     Stats(Options* opt, bool isRead2 = false, int guessedCycles = 0, int bufferMargin = 1024);
@@ -66,13 +68,36 @@ public:
     static string list2string(double* list, int size);
     static string list2string(double* list, int size, long* coords);
     static string list2string(long* list, int size);
-    static int base2val(char base) noexcept;
+
+    // Static lookup array for base values
+    static constexpr std::array<signed char, 256> BaseValueLookup = {
+        -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+        -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+        -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 0,  -1, 2,  -1, -1, -1, 3,  -1, -1, -1, -1, -1, -1,
+        -1, -1, -1, -1, -1, -1, 1,  -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+        -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+        -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+        -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+        -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+        -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+        -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+    };
+    static auto base2val(char base) noexcept -> std::int8_t;
 
     // Base types for all count/statistics vectors
     using CountVector = std::vector<long>;
 
     // Compound types for per-base cycle data
-    static constexpr std::size_t BaseCount = 8;
+    static constexpr std::array<unsigned char, 256> BaseIndexLookup = {
+        5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5,
+        5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 0, 5, 2, 5, 5, 5, 3, 5, 5,
+        5, 5, 5, 5, 4, 5, 5, 5, 5, 5, 1, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5,
+        5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5,
+        5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5,
+        5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5,
+        5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5,
+    };
+    static auto baseIndex(char base) noexcept -> std::size_t;
     using BaseArray = std::array<long, BaseCount>;
     using BaseCycleArray = std::array<CountVector, BaseCount>;
 
@@ -89,17 +114,8 @@ private:
     bool mIsRead2;
     long mReads;
     int mEvaluatedSeqLen;
-    /* 
-    why we use 8 here?
-    map A/T/C/G/N to 0~7 by their ASCII % 8:
-    'A' % 8 = 1
-    'T' % 8 = 4
-    'C' % 8 = 3
-    'G' % 8 = 7
-    'N' % 8 = 6
-    */
-    // TODO: replace this indexing system as it wastes memory
-    // TODO: using structs would likely improve cache locality for some of these
+
+    // Per-base statistics
     BaseCycleArray mCycleQ30Bases;
     BaseCycleArray mCycleQ20Bases;
     BaseCycleArray mCycleBaseContents;

--- a/src/stats.h
+++ b/src/stats.h
@@ -31,16 +31,17 @@ public:
     static constexpr std::size_t KmerLen   = 5;
     static constexpr std::size_t KmerCount = 1U << (2 * KmerLen);
     static constexpr std::size_t KmerMask  = KmerCount - 1;
+    using KmerArray = std::array<long, KmerCount>;
 
     // this @guessedCycles parameter should be calculated using the first several records
     Stats(Options* opt, bool isRead2 = false, int guessedCycles = 0, int bufferMargin = 1024);
     ~Stats() = default;
 
     // Copy and move constructors/assignment operators
-    Stats(const Stats& other);
-    Stats(Stats&& other) noexcept;
-    auto operator=(const Stats& other) -> Stats&;
-    auto operator=(Stats&& other) noexcept -> Stats&;
+    Stats(const Stats& other) = default;
+    Stats(Stats&& other) noexcept = default;
+    auto operator=(const Stats& other) -> Stats& = default;
+    auto operator=(Stats&& other) noexcept -> Stats& = default;
 
     int getCycles();
     long getReads();
@@ -171,7 +172,8 @@ private:
 
     CountVector mCycleTotalBase;
     CountVector mCycleTotalQual;
-    CountVector mKmer;
+
+    KmerArray mKmer;
 
     //TODO: Replace with const?
     std::array<long, 128> mBaseQualHistogram{}; // Initializing at construction like this is preferred

--- a/src/stats.h
+++ b/src/stats.h
@@ -199,6 +199,7 @@ private:
     long mKmerMax;
     long mKmerMin;
     long mLengthSum;
+    long mKmerTotal;
 };
 
 #endif

--- a/src/stats.h
+++ b/src/stats.h
@@ -46,7 +46,7 @@ public:
     static string list2string(double* list, int size);
     static string list2string(double* list, int size, long* coords);
     static string list2string(long* list, int size);
-    static int base2val(char base);
+    static int base2val(char base) noexcept;
 
 private:
     void extendBuffer(int newBufLen);

--- a/src/stats.h
+++ b/src/stats.h
@@ -29,6 +29,13 @@ public:
     // this @guessedCycles parameter should be calculated using the first several records
     Stats(Options* opt, bool isRead2 = false, int guessedCycles = 0, int bufferMargin = 1024);
     ~Stats() = default;
+
+    // Copy and move constructors/assignment operators
+    Stats(const Stats& other);
+    Stats(Stats&& other) noexcept;
+    auto operator=(const Stats& other) -> Stats&;
+    auto operator=(Stats&& other) noexcept -> Stats&;
+
     int getCycles();
     long getReads();
     long getBases();
@@ -44,13 +51,13 @@ public:
     void print();
     void summarize(bool forced = false);
     // a port of JSON report
-    void reportJson(ofstream& ofs, string padding);
+    void reportJson(ofstream& ofs, const string& padding);
     // a port of HTML report
-    void reportHtml(ofstream& ofs, string filteringType, string readName);
-    void reportHtmlQuality(ofstream& ofs, string filteringType, string readName);
-    void reportHtmlContents(ofstream& ofs, string filteringType, string readName);
-    void reportHtmlKMER(ofstream& ofs, string filteringType, string readName);
-    void reportHtmlORA(ofstream& ofs, string filteringType, string readName);
+    void reportHtml(ofstream& ofs, const string& filteringType, const string& readName);
+    void reportHtmlQuality(ofstream& ofs, const string& filteringType, const string& readName);
+    void reportHtmlContents(ofstream& ofs, const string& filteringType, const string& readName);
+    void reportHtmlKMER(ofstream& ofs, const string& filteringType, const string& readName);
+    void reportHtmlORA(ofstream& ofs, const string& filteringType, const string& readName);
     bool isLongRead();
     void initOverRepSeq();
     int getMeanLength();

--- a/src/stats.h
+++ b/src/stats.h
@@ -28,6 +28,10 @@ public:
     static auto qualityCurveIndex(CurveKey key) noexcept -> std::size_t;
     static auto contentCurveIndex(CurveKey key) noexcept -> std::size_t;
 
+    static constexpr std::size_t KmerLen   = 5;
+    static constexpr std::size_t KmerCount = 1U << (2 * KmerLen);
+    static constexpr std::size_t KmerMask  = KmerCount - 1;
+
     // this @guessedCycles parameter should be calculated using the first several records
     Stats(Options* opt, bool isRead2 = false, int guessedCycles = 0, int bufferMargin = 1024);
     ~Stats() = default;
@@ -189,7 +193,6 @@ private:
     bool summarized;
     long mKmerMax;
     long mKmerMin;
-    int mKmerBufLen;
     long mLengthSum;
 };
 

--- a/src/stats.h
+++ b/src/stats.h
@@ -67,6 +67,7 @@ public:
     bool isLongRead();
     void initOverRepSeq();
     int getMeanLength();
+    static auto test() -> bool;
 
 public:
     static string list2string(double* list, int size);

--- a/src/unittest.cpp
+++ b/src/unittest.cpp
@@ -10,11 +10,9 @@
 #include "nucleotidetree.h"
 #include "evaluator.h"
 #include "matcher.h"
-#include <time.h>
+#include "stats.h"
 
-UnitTest::UnitTest(){
-
-}
+UnitTest::UnitTest()= default;
 
 void UnitTest::run(){
     bool passed = true;
@@ -28,6 +26,7 @@ void UnitTest::run(){
     passed &= report(PolyX::test(), "PolyX::test");
     passed &= report(Matcher::test(), "Matcher::test");
     passed &= report(NucleotideTree::test(), "NucleotideTree::test");
+    passed &= report(Stats::test(), "Stats::test");
     passed &= report(Evaluator::test(), "Evaluator::test");
     printf("\n==========================\n");
     printf("%s\n\n", passed?"ALL PASSED":"FAILED");


### PR DESCRIPTION
- **refactor(stats): optimize base2val lookup with static array**
  Replaced switch statement in base2val with a static lookup table for
  more efficient and cleaner code. Added noexcept specifier to clarify no
  exceptions are thrown. This reduces branching and improves performance
  for frequent base conversions.
  

- **refactor(stats): replace raw pointers with STL containers**
  Refactored stats.cpp and stats.h to replace raw pointers and manual
  memory management with STL containers (std::vector, std::array,
  std::unordered_map). This change eliminates manual memory allocation,
  deallocation, and reduces the risk of memory leaks.
  
  Also updated related files (evaluator, htmlreporter, options) to use
  std::unordered_map instead of std::map for consistency with the new
  stats implementation. Adjusted method signatures and iterators
  accordingly.
  
  This refactor improves code safety, readability, and modernizes the
  codebase with idiomatic C++ practices.
  

- **refactor(stats): add CurveKey enum and indexing infrastructure**
  - Add CurveKey enum with A, T, C, G, N, Mean, GC values
  - Add static lookup arrays (QualityOrder, ContentOrder, QualityNames,
    ContentNames, QualityIndex, ContentIndex)
  - Add qualityCurveIndex() and contentCurveIndex() helper functions
  - Add missing includes for cstddef and cstring
  - Add size constants (QualityCurveSize, ContentCurveSize,
    CurveIndexSize)
  

- **refactor(stats): replace curve maps with fixed-size arrays**
  - Change mQualityCurves from unordered_map<string, vector<double>> to
    array<vector<double>, QualityCurveSize>
  - Change mContentCurves from unordered_map<string, vector<double>> to
    array<vector<double>, ContentCurveSize>
  

- **refactor(stats): use enum indexing in summarize() method**
  - Replace hardcoded string loops with enum-based iteration
  - Use move semantics for better performance
  - Update curve assignment to use helper functions instead of string keys
  

- **refactor(stats): update JSON and HTML reporting to use enum indexing**
  - Replace hardcoded string arrays with static lookup arrays
  - Use range-based for loops with enum iteration
  - Qualify standard lib methods with std::
  

- **refactor(stats): improve const-correctness of string parameters**
  - Make string parameters const references in reportJson(), reportHtml(),
    and related methods
  - Add copy/move constructor declarations
  

- **refactor(stats): replace bitmask base indexing with array lookup**
  Replaced legacy base indexing via bitmasking (base & 0x07) with a
  constexpr lookup table (`baseIndex()`), improving correctness and
  maintainability.
  
  Performance impact:
  - L1-dcache-load-misses decreased by ~0.92%
  - L1-icache-loads decreased by ~0.73%
  - branch-instructions decreased by ~0.39%
  - instructions decreased by ~0.43%
  - overall cycles neutral to slightly decreased
  - cache-misses increased slightly (+0.24%), balanced by fewer L1 misses
  
  This change improves code clarity while reducing instruction and branch
  count with neutral-to-positive runtime performance.
  

- **refactor(stats): simplify quality score counting logic with booleans**
  This eliminates those branches in the loop and eliminates the chance of
  branch mispredictions.
  

- **perf(stats): flatten BaseCycleArray from 2D to 1D structure**
  - Change BaseCycleArray from std::array<CountVector, BaseCount> to
    std::vector<long>
  - Replace array[baseIdx][cycleIdx] access with flattened indexing:
    array[(baseIdx * mBufLen) + cycleIdx]
  - Rewrite extendBuffer() to handle flattened memory layout with
    resizeFlat lambda
  - Update constructor, summarize(), statRead(), and merge() methods for
    new structure
  - Improves memory layout and cache locality for cycle-based statistics
  

- **refactor(stats): introduce BaseCycleArray container for 2D statistics**
  - Replace flat vector with manual indexing with encapsulated 2D
    container
  - Add BaseCycleArray struct with operator() for cleaner 2D access
  - Simplify buffer resize logic by removing complex manual copying
  - Improve type safety and code readability throughout stats operations
  - Maintain existing functionality while reducing indexing complexity
  
  NOTE: this introduced a slight performance regression which will be
  rectified, and this commit will be squashed/modified.
  

- **fix(stats): correct array indexing in resize method**
  - Fix out-of-bounds access by using proper 2D-to-1D index calculation
  - Replace incorrect newSize + cycleIdx with (baseIdx * newLen) + cycleIdx
  - Remove unused newSize variable
  

- **perf(stats): optimize cycle data access with direct vector operations**
  Replace 2D array-style operator() calls with direct vector access and
  manual offset calculation in statRead hot path. This eliminates function
  call overhead and improves memory access patterns.
  
  Performance improvements:
  - L1 cache misses: -15.3% average reduction
  - Cache references: -12.3% average reduction
  - Instructions executed: -1.8% average reduction
  - CPU cycles: -2.7% average reduction
  - dTLB loads: -10.6% average reduction
  

- **perf(stats): optimize memory layout for better cache locality**
  - Change BaseCycleArray from base-major to cycle-major ordering
  - Swap parameter order from (base, cycle) to (cycle, base)
  - Reorder nested loops to match new memory layout
  - Update index calculation to use (cycle * bases) + base
  
  This improves cache locality when iterating through cycles, resulting in
  significant reductions in cache misses and overall execution time.
  

- **refactor(stats): replace loop with std::array::fill for zero init**
  Simplifies initialization of mQ20Bases, mQ30Bases, and mBaseContents
  by using std::array::fill, improving readability.
  

- **refactor(stats): replace KMER_LEN macro with constexpr KmerLen**
  Replaces the KMER_LEN macro with a scoped constexpr KmerLen, and
  replaces manual mKmerBufLen calculation with KmerCount constexpr. This
  improves code readability and type safety, while removing an unused
  member variable.
  

- **test(stats): add regression tests for kmer calculations**
  

- **refactor(stats): replace hard-coded k-mer mask with constant**
  

- **refactor(stats): replace dynamic kmer container with compile-time array**
  - Replace CountVector mKmer with std::array<long, KmerCount> for better
    performance
  - Use KmerArray type alias for improved readability and maintainability
  - Replace mKmer.size() calls with compile-time constant Stats::KmerCount
  - Use std::array::fill() instead of std::vector::assign() for
    initialization
  - Default copy/move constructors and assignment operators for better
    efficiency
  - Add static_cast for explicit type conversion in meanBases calculation
  
  This change leverages compile-time constants for better optimization and
  type safety while maintaining the same functionality.
  

- **perf(stats): cache k-mer labels to avoid repeated string concatenation**
  - Pre-compute k-mer string labels during Stats constructor
  - Replace dynamic kmer2()/kmer3() calls with cached lookups
  - Improves performance of HTML k-mer report generation
  

- **fix(stats): use total k-mer count instead of base count**
  The original implementation incorrectly used mBases (total bases
  processed) as the denominator for calculating expected k-mer frequency.
  This is mathematically wrong because:
  
  - For k-mer frequency analysis, the relevant denominator should be the
    total number of k-mer observations, not the number of bases
  - In a sequence of length L, there are only (L-k+1) possible k-mer
    positions, not L positions
  - Using mBases systematically underestimates expected frequency since
    mBases > total_kmer_positions, leading to inflated enrichment ratios
  
  Changes:
  - Add mKmerTotal to track sum of all k-mer observations
  - Replace mBases with mKmerTotal in meanBases calculation
  - Add test assertion for mKmerTotal computation
  
  This aligns with standard bioinformatics practice where k-mer enrichment
  is calculated as observed_count / (total_kmers / possible_kmer_types).
  

- **refactor(stats): modernize with explicit std namespace, STL algorithms**
  - Replace manual loops with std::accumulate for Q20/Q30/Q40 total
    calculations
  - Use std::transform with std::plus<long>() for kmer array merging
  - Explicitly qualify all standard library types (string->std::string,
    vector->std::vector, etc.)
  - Replace unqualified max/min calls with std::max/std::min for namespace
    safety
  - Convert endl to "\n" for improved performance (avoid unnecessary
    buffer flushes)
  - Add <functional> header for std::plus function object
  - Remove unused variable declarations and improve type deduction with
    auto
  - Standardize stream output with std::cerr and std::ofstream
  