### PR TITLE
fix/use new ring buffer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,118 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Build and Development Commands
+
+### Building fastp
+```bash
+# Build regular version
+make -j
+
+# Build static version (Linux)
+make -j static
+
+# Clean build artifacts
+make clean
+
+# Install to system
+sudo make install
+```
+
+### Development Tools
+```bash
+# Run unit tests
+./fastp test
+
+# Check version
+./fastp --version
+
+# Build with sanitizers for debugging
+./scripts/build_with_sanitizer.sh {asan|msan|tsan|ubsan|valgrind}
+```
+
+### Dependencies
+The project depends on external libraries:
+- `libisal` - Intel Storage Acceleration Library for compression
+- `libdeflate` - Fast deflate compression library
+- Standard C++ threading libraries
+
+## Code Architecture
+
+### Core Components
+
+**Main Processing Flow:**
+- `main.cpp` - Entry point with command-line parsing
+- `options.cpp/h` - Configuration and option management
+- `processor.cpp/h` - Main processing coordinator
+- `peprocessor.cpp/h` - Paired-end read processing
+- `seprocessor.cpp/h` - Single-end read processing
+
+**I/O and Data Structures:**
+- `fastqreader.cpp/h` - FASTQ file reading with threading
+- `writer.cpp/h` and `writerthread.cpp/h` - Multi-threaded output writing
+- `read.cpp/h` and `sequence.cpp/h` - Read and sequence data structures
+- `readpool.cpp/h` - Memory pool for read objects
+
+**Processing Modules:**
+- `adaptertrimmer.cpp/h` - Adapter detection and trimming
+- `filter.cpp/h` - Quality and length filtering
+- `basecorrector.cpp/h` - Base correction for overlapping PE reads
+- `polyx.cpp/h` - PolyX tail trimming (polyG, polyA, etc.)
+- `duplicate.cpp/h` - Duplication detection and removal
+- `umiprocessor.cpp/h` - UMI (Unique Molecular Identifier) processing
+
+**Analysis and Reporting:**
+- `stats.cpp/h` - Statistics collection and calculation
+- `evaluator.cpp/h` - Quality evaluation and metrics
+- `htmlreporter.cpp/h` - HTML report generation
+- `jsonreporter.cpp/h` - JSON report generation
+- `overlapanalysis.cpp/h` - Read overlap analysis for PE data
+
+**Utilities:**
+- `matcher.cpp/h` - Pattern matching for adapter detection
+- `nucleotidetree.cpp/h` - Tree structure for sequence analysis
+- `threadconfig.cpp/h` - Threading configuration
+- `util.h` and `common.h` - Utility functions and common definitions
+
+### Key Design Patterns
+
+**Multi-threading Architecture:**
+- Uses producer-consumer pattern with `spsc_ring_buffer.h`
+- Separate threads for reading, processing, and writing
+- Thread-safe statistics collection
+
+**Memory Management:**
+- Object pooling for reads to reduce allocation overhead
+- Efficient string handling for sequences
+- RAII patterns throughout
+
+**Performance Optimizations:**
+- The codebase is highly optimized for speed
+- Recent commits show performance improvements in stats calculation and sequence matching
+- Uses Intel ISA-L and libdeflate for fast compression
+
+## Testing
+
+The project includes a built-in unit test framework:
+```bash
+./fastp test
+```
+
+Test data is available in the `testdata/` directory with sample R1.fq and R2.fq files.
+
+## Key Features Implementation
+
+- **Adapter Detection**: Automatic detection for most common adapters, manual specification supported
+- **Quality Filtering**: Multiple quality metrics with configurable thresholds
+- **Multi-format Support**: Handles single-end, paired-end, and interleaved FASTQ
+- **Reporting**: Comprehensive HTML and JSON reports with visualizations
+- **Batch Processing**: `parallel.py` script for processing multiple files
+
+## Working with the Code
+
+- The codebase follows standard C++11 practices
+- All headers are in `src/` (no separate `inc/` directory used)
+- Uses standard make build system
+- Code is performance-critical - be careful with changes that might affect speed
+- Recent work has focused on optimizing stats calculation and sequence matching algorithms

--- a/src/peprocessor.h
+++ b/src/peprocessor.h
@@ -43,6 +43,8 @@ private:
     void recycleToPool1(int tid, Read* r);
     void recycleToPool2(int tid, Read* r);
 
+    static constexpr int InputQueueCapacity = PACK_IN_MEM_LIMIT + 1;
+
 private:
     atomic_bool mLeftReaderFinished;
     atomic_bool mRightReaderFinished;

--- a/src/seprocessor.h
+++ b/src/seprocessor.h
@@ -4,6 +4,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string>
+#include "common.h"
 #include "read.h"
 #include <cstdlib>
 #include <condition_variable>
@@ -38,6 +39,8 @@ private:
     void writerTask(WriterThread* config);
     void recycleToPool(int tid, Read* r);
 
+    static constexpr int InputQueueCapacity = PACK_IN_MEM_LIMIT + 1;
+
 private:
     Options* mOptions;
     atomic_bool mReaderFinished;
@@ -48,8 +51,6 @@ private:
     WriterThread* mFailedWriter;
     Duplicate* mDuplicate;
     SingleProducerSingleConsumerList<ReadPack*>** mInputLists;
-    size_t mPackReadCounter;
-    atomic_long mPackProcessedCounter;
     ReadPool* mReadPool;
 };
 


### PR DESCRIPTION
- **chore: add guidelines**
  

- **refactor(seprocessor): use blocking queue backpressure**
  Replace manual thread coordination counters (mPackReadCounter,
  mPackProcessedCounter) with constrained blocking queue capacity.
  
  - Add constexpr InputQueueCapacity for queue sizing (PACK_IN_MEM_LIMIT +
    1)
  - Remove sleep-based backpressure loops in readerTask
  - Use local packCounter variable for round-robin distribution
  - Eliminate explicit coordination between reader and processor threads
  
  The blocking queue automatically provides backpressure when processors
  fall behind, simplifying the threading model.
  

- **refactor(processor): replace manual backpressure with queue blocking**
  - Remove atomic pack counters (mLeftPackReadCounter,
    mRightPackReadCounter, mPackProcessedCounter)
  - Replace manual sleep-based coordination with SPSCRingBuffer blocking
    semantics
  - Add InputQueueCapacity constant (PACK_IN_MEM_LIMIT + 1) for proper
    ring buffer sizing
  - Modernize WriterThread with C++11 features:
    - Use std::unique_ptr for automatic memory management
    - Add std::atomic_bool for thread-safe completion tracking
    - Remove manual buffer length tracking in favor of built-in queue
      state checking
    - Add copy/move constructors deletion for thread safety
    - Improve const correctness and defensive programming
  - Replace member counters with local variables in reader threads
  - Simplify interleaved reader to use single counter for both queues
  
  This eliminates race-prone manual coordination while maintaining
  identical distribution patterns and improving code maintainability.
  